### PR TITLE
Bump version to 0.3.1 in Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "labelme2yolo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labelme2yolo"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This pull request makes a minor update to the project version in the `Cargo.toml` file, incrementing it from 0.3.0 to 0.3.1.