### PR TITLE
feat(config): Add custom output directory support and refactor path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "labelme2yolo"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labelme2yolo"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [[bin]]

--- a/src/coco.rs
+++ b/src/coco.rs
@@ -226,7 +226,7 @@ impl CocoWriter {
 
 /// Calculate polygon area using the shoelace formula
 pub fn calculate_polygon_area(polygon: &[f64]) -> f64 {
-    if polygon.len() < 6 || polygon.len() % 2 != 0 {
+    if polygon.len() < 6 || !polygon.len().is_multiple_of(2) {
         return 0.0;
     }
 
@@ -247,7 +247,7 @@ pub fn calculate_polygon_area(polygon: &[f64]) -> f64 {
 
 /// Calculate bounding box from polygon points
 pub fn calculate_bbox_from_polygon(polygon: &[f64]) -> [f64; 4] {
-    if polygon.len() < 6 || polygon.len() % 2 != 0 {
+    if polygon.len() < 6 || !polygon.len().is_multiple_of(2) {
         return [0.0, 0.0, 0.0, 0.0];
     }
 

--- a/src/coco_dataset.rs
+++ b/src/coco_dataset.rs
@@ -104,7 +104,11 @@ pub fn setup_coco_output_directories(
     args: &Args,
     dirname: &Path,
 ) -> std::io::Result<CocoOutputDirs> {
-    let base_dir = dirname.join("COCODataset");
+    let base_dir = if let Some(ref output_dir) = args.output_dir {
+        PathBuf::from(output_dir)
+    } else {
+        dirname.join("COCODataset")
+    };
     let annotations_dir = create_output_directory(&base_dir.join("annotations"))?;
     let images_dir = create_output_directory(&base_dir.join("images"))?;
 
@@ -336,7 +340,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
             let count = processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
             let update_counter =
                 message_update_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-            if update_counter % MESSAGE_UPDATE_INTERVAL == 0 {
+            if update_counter.is_multiple_of(MESSAGE_UPDATE_INTERVAL) {
                 pb.set_message(format!("Processed {} files...", count));
             }
         });
@@ -523,7 +527,7 @@ fn process_annotation_for_coco(params: ProcessAnnotationParams) {
         annotation.image_height,
     );
 
-    // Process shapes
+    // Process shapes - filter to only those in label_map
     let mut annotations = Vec::new();
     for shape in &annotation.shapes {
         if let Some(class_id) = label_map.get(&shape.label) {

--- a/src/coco_dataset.rs
+++ b/src/coco_dataset.rs
@@ -18,8 +18,8 @@ use crate::coco::{Annotation, CocoConfig, CocoFile, Image};
 use crate::config::Args;
 use crate::types::{ImageAnnotation, Shape};
 use crate::utils::{
-    create_io_thread_pool, create_output_directory, infer_image_format, read_and_parse_json,
-    read_and_parse_json_buffered, read_and_parse_json_streaming,
+    create_io_thread_pool, create_output_directory, get_base_output_dir, infer_image_format,
+    read_and_parse_json, read_and_parse_json_buffered, read_and_parse_json_streaming,
 };
 
 /// Struct to hold the paths to the output directories for COCO dataset
@@ -104,11 +104,7 @@ pub fn setup_coco_output_directories(
     args: &Args,
     dirname: &Path,
 ) -> std::io::Result<CocoOutputDirs> {
-    let base_dir = if let Some(ref output_dir) = args.output_dir {
-        PathBuf::from(output_dir)
-    } else {
-        dirname.join("COCODataset")
-    };
+    let base_dir = get_base_output_dir(args, dirname, "COCODataset");
     let annotations_dir = create_output_directory(&base_dir.join("annotations"))?;
     let images_dir = create_output_directory(&base_dir.join("images"))?;
 
@@ -213,6 +209,9 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
     // Create a custom thread pool with limited concurrency
     let thread_pool = create_io_thread_pool(args.workers);
 
+    // Compute the output directory to exclude from scanning
+    let output_base_dir = get_base_output_dir(args, dirname, "COCODataset");
+
     // Walk through the directory structure to find JSON files
     use jwalk::WalkDir;
     use rayon::prelude::*;
@@ -223,13 +222,18 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            // Skip COCO Dataset directories early by comparing directory names directly
+            // Skip output directories early by comparing directory paths
             if e.file_type().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    name != "COCODataset"
-                } else {
-                    false
+                let entry_path = e.path();
+                // Skip if this directory is the output directory or inside it
+                if entry_path.starts_with(&output_base_dir) {
+                    return false;
                 }
+                // Also skip legacy "COCODataset" directories for backward compatibility
+                if let Some(name) = e.file_name().to_str() {
+                    return name != "COCODataset";
+                }
+                false
             } else {
                 true
             }
@@ -781,6 +785,9 @@ fn process_background_images_for_coco(
     // Use the precomputed set of supported image extensions for fast lookup
     let image_extensions = crate::types::get_image_extensions_set();
 
+    // Compute the output directory to exclude from scanning
+    let output_base_dir = get_base_output_dir(args, dirname, "COCODataset");
+
     // Walk through the directory structure to find image files
     use jwalk::WalkDir;
     use rayon::prelude::*;
@@ -791,13 +798,18 @@ fn process_background_images_for_coco(
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            // Skip COCO Dataset directories early by comparing directory names directly
+            // Skip output directories early by comparing directory paths
             if e.file_type().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    name != "COCODataset"
-                } else {
-                    false
+                let entry_path = e.path();
+                // Skip if this directory is the output directory or inside it
+                if entry_path.starts_with(&output_base_dir) {
+                    return false;
                 }
+                // Also skip legacy "COCODataset" directories for backward compatibility
+                if let Some(name) = e.file_name().to_str() {
+                    return name != "COCODataset";
+                }
+                false
             } else {
                 true
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,10 @@ pub struct Args {
     #[arg(short = 'd', long = "json_dir")]
     pub json_dir: String,
 
+    /// Output directory for converted dataset (default: <json_dir>/YOLODataset or <json_dir>/COCODataset)
+    #[arg(short = 'o', long = "output_dir")]
+    pub output_dir: Option<String>,
+
     /// Proportion of the dataset to use for validation
     #[arg(long = "val_size", default_value_t = 0.2, value_parser = validate_size)]
     pub val_size: f32,

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,23 +3,19 @@ use jwalk::WalkDir;
 use rayon::prelude::*;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::config::Args;
 use crate::types::{OutputDirs, SplitData};
 use crate::utils::{
-    create_io_thread_pool, create_output_directory, read_and_parse_json,
+    create_io_thread_pool, create_output_directory, get_base_output_dir, read_and_parse_json,
     read_and_parse_json_buffered, read_and_parse_json_streaming,
 };
 
 /// Set up the directory structure for YOLO dataset output
 pub fn setup_output_directories(args: &Args, dirname: &Path) -> std::io::Result<OutputDirs> {
-    let base_dir = if let Some(ref output_dir) = args.output_dir {
-        PathBuf::from(output_dir)
-    } else {
-        dirname.join("YOLODataset")
-    };
+    let base_dir = get_base_output_dir(args, dirname, "YOLODataset");
     let labels_dir = create_output_directory(&base_dir.join("labels"))?;
     let images_dir = create_output_directory(&base_dir.join("images"))?;
 
@@ -63,20 +59,28 @@ pub fn process_json_files_streaming(
     // Create a custom thread pool with limited concurrency
     let thread_pool = create_io_thread_pool(args.workers);
 
+    // Compute the output directory to exclude from scanning
+    let output_base_dir = get_base_output_dir(args, dirname, "YOLODataset");
+
     // Walk through the directory structure to find JSON files using parallel jwalk
     let json_entries = WalkDir::new(dirname)
         .skip_hidden(false)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            // Skip YOLODataset directories early by comparing directory names directly
+            // Skip output directories early by comparing directory paths
             if e.file_type().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    name != "YOLODataset"
-                } else {
-                    // If we can't convert to str, skip to be safe
-                    false
+                let entry_path = e.path();
+                // Skip if this directory is the output directory or inside it
+                if entry_path.starts_with(&output_base_dir) {
+                    return false;
                 }
+                // Also skip legacy "YOLODataset" directories for backward compatibility
+                if let Some(name) = e.file_name().to_str() {
+                    return name != "YOLODataset";
+                }
+                // If we can't convert to str, skip to be safe
+                false
             } else {
                 true
             }
@@ -547,20 +551,28 @@ pub fn process_background_images(
     // Use the precomputed set of supported image extensions for fast lookup
     let image_extensions = crate::types::get_image_extensions_set();
 
+    // Compute the output directory to exclude from scanning
+    let output_base_dir = get_base_output_dir(args, dirname, "YOLODataset");
+
     // Walk through the directory structure to find image files using parallel jwalk
     let image_entries = WalkDir::new(dirname)
         .skip_hidden(false)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| {
-            // Skip YOLODataset directories early by comparing directory names directly
+            // Skip output directories early by comparing directory paths
             if e.file_type().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    name != "YOLODataset"
-                } else {
-                    // If we can't convert to str, skip to be safe
-                    false
+                let entry_path = e.path();
+                // Skip if this directory is the output directory or inside it
+                if entry_path.starts_with(&output_base_dir) {
+                    return false;
                 }
+                // Also skip legacy "YOLODataset" directories for backward compatibility
+                if let Some(name) = e.file_name().to_str() {
+                    return name != "YOLODataset";
+                }
+                // If we can't convert to str, skip to be safe
+                false
             } else {
                 true
             }
@@ -702,11 +714,7 @@ pub fn create_dataset_yaml(
     args: &Args,
     label_map: &dashmap::DashMap<String, usize>,
 ) -> std::io::Result<()> {
-    let base_dir = if let Some(ref output_dir) = args.output_dir {
-        PathBuf::from(output_dir)
-    } else {
-        dirname.join("YOLODataset")
-    };
+    let base_dir = get_base_output_dir(args, dirname, "YOLODataset");
     let dataset_yaml_path = base_dir.join("dataset.yaml");
     let mut dataset_yaml = BufWriter::new(File::create(&dataset_yaml_path)?);
     let absolute_path = fs::canonicalize(&base_dir)?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,7 +3,7 @@ use jwalk::WalkDir;
 use rayon::prelude::*;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::config::Args;
@@ -15,8 +15,13 @@ use crate::utils::{
 
 /// Set up the directory structure for YOLO dataset output
 pub fn setup_output_directories(args: &Args, dirname: &Path) -> std::io::Result<OutputDirs> {
-    let labels_dir = create_output_directory(&dirname.join("YOLODataset/labels"))?;
-    let images_dir = create_output_directory(&dirname.join("YOLODataset/images"))?;
+    let base_dir = if let Some(ref output_dir) = args.output_dir {
+        PathBuf::from(output_dir)
+    } else {
+        dirname.join("YOLODataset")
+    };
+    let labels_dir = create_output_directory(&base_dir.join("labels"))?;
+    let images_dir = create_output_directory(&base_dir.join("images"))?;
 
     let train_labels_dir = create_output_directory(&labels_dir.join("train"))?;
     let val_labels_dir = create_output_directory(&labels_dir.join("val"))?;
@@ -238,7 +243,7 @@ pub fn process_json_files_streaming(
                 let count = processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 let update_counter =
                     message_update_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if update_counter % MESSAGE_UPDATE_INTERVAL == 0 {
+                if update_counter.is_multiple_of(MESSAGE_UPDATE_INTERVAL) {
                     pb.set_message(format!("Processed {} files...", count));
                 }
             } else if let Some(mut streaming_annotation) =
@@ -364,7 +369,7 @@ pub fn process_json_files_streaming(
                 let count = processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 let update_counter =
                     message_update_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if update_counter % MESSAGE_UPDATE_INTERVAL == 0 {
+                if update_counter.is_multiple_of(MESSAGE_UPDATE_INTERVAL) {
                     pb.set_message(format!("Processed {} files...", count));
                 }
             } else if let Some(annotation) = read_and_parse_json(&json_path, args.buffer_size_kib) {
@@ -489,7 +494,7 @@ pub fn process_json_files_streaming(
                 let count = processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 let update_counter =
                     message_update_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if update_counter % MESSAGE_UPDATE_INTERVAL == 0 {
+                if update_counter.is_multiple_of(MESSAGE_UPDATE_INTERVAL) {
                     pb.set_message(format!("Processed {} files...", count));
                 }
             }
@@ -680,7 +685,7 @@ pub fn process_background_images(
                     let update_counter = bg_message_update_count
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         + 1;
-                    if update_counter % BG_MESSAGE_UPDATE_INTERVAL == 0 {
+                    if update_counter.is_multiple_of(BG_MESSAGE_UPDATE_INTERVAL) {
                         pb.set_message(format!("Processed {} background images...", count));
                     }
                 }
@@ -697,9 +702,14 @@ pub fn create_dataset_yaml(
     args: &Args,
     label_map: &dashmap::DashMap<String, usize>,
 ) -> std::io::Result<()> {
-    let dataset_yaml_path = dirname.join("YOLODataset/dataset.yaml");
+    let base_dir = if let Some(ref output_dir) = args.output_dir {
+        PathBuf::from(output_dir)
+    } else {
+        dirname.join("YOLODataset")
+    };
+    let dataset_yaml_path = base_dir.join("dataset.yaml");
     let mut dataset_yaml = BufWriter::new(File::create(&dataset_yaml_path)?);
-    let absolute_path = fs::canonicalize(dirname.join("YOLODataset"))?;
+    let absolute_path = fs::canonicalize(&base_dir)?;
     let mut yaml_content = format!(
         "path: {}\ntrain: images/train\nval: images/val\n",
         absolute_path.to_string_lossy()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,10 +5,20 @@ use rayon;
 use serde_json;
 use std::fs;
 use std::io::{BufReader, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 
+use crate::config::Args;
 use crate::types::{ImageAnnotation, StreamingImageAnnotation};
+
+/// Get the base output directory based on args.output_dir or a default subdirectory
+pub fn get_base_output_dir(args: &Args, json_dir_path: &Path, default_subdir: &str) -> PathBuf {
+    if let Some(ref output_dir) = args.output_dir {
+        PathBuf::from(output_dir)
+    } else {
+        json_dir_path.join(default_subdir)
+    }
+}
 
 /// Helper function to infer image format from image bytes
 pub fn infer_image_format(image_bytes: &[u8]) -> Option<&'static str> {


### PR DESCRIPTION
- Add `output_dir` optional command-line argument to specify custom output directory
- Replace modulo operator with `is_multiple_of()` method for cleaner divisibility checks in coco.rs
- Update `setup_output_directories()` to use custom output directory when provided
- Update `setup_coco_output_directories()` to use custom output directory when provided
- Update `create_dataset_yaml()` to respect custom output directory configuration
- Refactor path handling in io.rs to support both default and custom output locations
- Apply `is_multiple_of()` consistently across all progress update counter checks
- Bump version to 0.3.2 in Cargo.toml and Cargo.lock
- Improves flexibility by allowing users to specify output location instead of hardcoded defaults