### PR TITLE
feat: Support multiple --json_dir/-d source directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "labelme2yolo"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labelme2yolo"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ pip install labelme2yolo
 
 ## Options
 
-**-d, --json_dir <JSON_DIR>** Directory containing LabelMe JSON files.
+**-d, --json_dir <JSON_DIR>** Directory containing LabelMe JSON files. Repeat the flag to convert multiple directories in one run (requires `--output_dir`).
+
+**-o, --output_dir <OUTPUT_DIR>** Output directory for the converted dataset [default: `<json_dir>/YOLODataset`]. Required when multiple `--json_dir` values are given.
 
 **--val_size <VAL_SIZE>** Proportion of the dataset to use for validation (between 0.0 and 1.0) [default: 0.2].
 
@@ -80,6 +82,16 @@ This tool will generate dataset labels and images with YOLO format in different 
 /path/to/labelme_json_dir/YOLODataset/images/val/
 /path/to/labelme_json_dir/YOLODataset/dataset.yaml
 ```
+
+### 3. Converting multiple directories into one dataset
+
+Pass `--json_dir` multiple times to combine several source directories. An explicit `--output_dir` is required in this case:
+
+```shell
+labelme2yolo -d /path/to/src-a/ -d /path/to/src-b/ -o /path/to/output/
+```
+
+Files with the same name in different source directories are kept apart automatically.
 
 ## How to build package/wheel
 

--- a/src/coco_dataset.rs
+++ b/src/coco_dataset.rs
@@ -16,7 +16,7 @@ use std::sync::{
 
 use crate::coco::{Annotation, CocoConfig, CocoFile, Image};
 use crate::config::Args;
-use crate::types::{ImageAnnotation, Shape};
+use crate::types::{ImageAnnotation, Shape, SourceRoot};
 use crate::utils::{
     create_io_thread_pool, create_output_directory, get_base_output_dir, infer_image_format,
     read_and_parse_json, read_and_parse_json_buffered, read_and_parse_json_streaming,
@@ -56,7 +56,7 @@ type ProcessBackgroundImagesResult =
 /// Parameters for processing JSON files for COCO conversion
 #[derive(Debug)]
 struct ProcessJsonFilesParams<'a> {
-    dirname: &'a Path,
+    source_roots: &'a [SourceRoot],
     args: &'a Args,
     output_dirs: &'a CocoOutputDirs,
     label_map: &'a DashMap<String, usize>,
@@ -129,9 +129,13 @@ pub fn setup_coco_output_directories(
 pub fn process_coco_dataset(
     output_dirs: &CocoOutputDirs,
     args: &Args,
-    dirname: &Path,
+    source_roots: &[SourceRoot],
     coco_config: &CocoConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if source_roots.is_empty() {
+        return Err("No source directories provided".into());
+    }
+
     // Use a local HashMap for initialization to avoid DashMap overhead
     let mut label_map_local = HashMap::new();
     let next_class_id = Arc::new(AtomicUsize::new(0));
@@ -156,7 +160,7 @@ pub fn process_coco_dataset(
     info!("Processing JSON files for COCO conversion...");
     let (train_data, val_data, test_data, processed_image_basenames) =
         process_json_files_for_coco(ProcessJsonFilesParams {
-            dirname,
+            source_roots,
             args,
             output_dirs,
             label_map: &label_map,
@@ -169,7 +173,7 @@ pub fn process_coco_dataset(
     // Process background images
     info!("Processing background images for COCO conversion...");
     let (train_bg_images, val_bg_images, test_bg_images) = process_background_images_for_coco(
-        dirname,
+        source_roots,
         args,
         output_dirs,
         &processed_image_basenames,
@@ -197,7 +201,7 @@ pub fn process_coco_dataset(
 /// Process JSON files for COCO conversion
 fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFilesResult {
     let ProcessJsonFilesParams {
-        dirname,
+        source_roots,
         args,
         output_dirs,
         label_map,
@@ -209,40 +213,48 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
     // Create a custom thread pool with limited concurrency
     let thread_pool = create_io_thread_pool(args.workers);
 
-    // Compute the output directory to exclude from scanning
-    let output_base_dir = get_base_output_dir(args, dirname, "COCODataset");
-
-    // Walk through the directory structure to find JSON files
+    // Walk through each source directory to find JSON files
     use jwalk::WalkDir;
     use rayon::prelude::*;
     use std::sync::Mutex;
 
-    let json_entries = WalkDir::new(dirname)
-        .skip_hidden(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            // Skip output directories early by comparing directory paths
-            if e.file_type().is_dir() {
-                let entry_path = e.path();
-                // Skip if this directory is the output directory or inside it
-                if entry_path.starts_with(&output_base_dir) {
-                    return false;
-                }
-                // Also skip legacy "COCODataset" directories for backward compatibility
-                if let Some(name) = e.file_name().to_str() {
-                    return name != "COCODataset";
-                }
-                false
-            } else {
-                true
-            }
+    // The walkers must be created eagerly (collect) on the current thread:
+    // jwalk schedules its traversal with rayon::spawn, and creating a walker
+    // from inside the saturated worker pool below would starve that spawn and
+    // make jwalk silently return no entries after its startup timeout.
+    let json_walkers: Vec<_> = source_roots
+        .iter()
+        .map(|root| {
+            // Compute the output directory to exclude from scanning
+            let output_base_dir = get_base_output_dir(args, &root.path, "COCODataset");
+            WalkDir::new(&root.path)
+                .skip_hidden(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(move |e| {
+                    // Skip output directories early by comparing directory paths
+                    if e.file_type().is_dir() {
+                        let entry_path = e.path();
+                        // Skip if this directory is the output directory or inside it
+                        if entry_path.starts_with(&output_base_dir) {
+                            return false;
+                        }
+                        // Also skip legacy "COCODataset" directories for backward compatibility
+                        if let Some(name) = e.file_name().to_str() {
+                            return name != "COCODataset";
+                        }
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .filter(|e| {
+                    e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
+                })
+                .map(move |e| (root, e.path().to_path_buf()))
         })
-        .filter(|e| {
-            e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
-        })
-        .map(|e| e.path().to_path_buf())
-        .par_bridge();
+        .collect();
+    let json_entries = json_walkers.into_iter().flatten().par_bridge();
 
     // Create counters for tracking processed files
     let processed_count = std::sync::atomic::AtomicUsize::new(0);
@@ -276,7 +288,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
 
     // Process JSON files in parallel
     thread_pool.install(|| {
-        json_entries.for_each(|json_path| {
+        json_entries.for_each(|(root, json_path)| {
             // Try to parse with simd-json for faster performance
             if let Some(annotation) = read_and_parse_json_buffered(&json_path, args.buffer_size_kib)
             {
@@ -289,7 +301,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                     next_class_id,
                     coco_config,
                     processed_image_basenames: &processed_image_basenames,
-                    base_dir: dirname,
+                    base_dir: &root.path,
                     train_data: &train_data,
                     val_data: &val_data,
                     test_data: &test_data,
@@ -310,7 +322,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                         next_class_id,
                         coco_config,
                         processed_image_basenames: &processed_image_basenames,
-                        base_dir: dirname,
+                        base_dir: &root.path,
                         train_data: &train_data,
                         val_data: &val_data,
                         test_data: &test_data,
@@ -328,7 +340,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                     next_class_id,
                     coco_config,
                     processed_image_basenames: &processed_image_basenames,
-                    base_dir: dirname,
+                    base_dir: &root.path,
                     train_data: &train_data,
                     val_data: &val_data,
                     test_data: &test_data,
@@ -768,7 +780,7 @@ fn convert_shape_to_coco_annotation(
 
 /// Process background images for COCO conversion
 fn process_background_images_for_coco(
-    dirname: &Path,
+    source_roots: &[SourceRoot],
     args: &Args,
     output_dirs: &CocoOutputDirs,
     processed_image_basenames: &std::collections::HashSet<String>,
@@ -785,47 +797,54 @@ fn process_background_images_for_coco(
     // Use the precomputed set of supported image extensions for fast lookup
     let image_extensions = crate::types::get_image_extensions_set();
 
-    // Compute the output directory to exclude from scanning
-    let output_base_dir = get_base_output_dir(args, dirname, "COCODataset");
-
-    // Walk through the directory structure to find image files
+    // Walk through each source directory to find image files
     use jwalk::WalkDir;
     use rayon::prelude::*;
     use std::sync::Mutex;
 
-    let image_entries = WalkDir::new(dirname)
-        .skip_hidden(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            // Skip output directories early by comparing directory paths
-            if e.file_type().is_dir() {
-                let entry_path = e.path();
-                // Skip if this directory is the output directory or inside it
-                if entry_path.starts_with(&output_base_dir) {
-                    return false;
-                }
-                // Also skip legacy "COCODataset" directories for backward compatibility
-                if let Some(name) = e.file_name().to_str() {
-                    return name != "COCODataset";
-                }
-                false
-            } else {
-                true
-            }
+    // Walkers are created eagerly for the same reason as in
+    // process_json_files_for_coco: creating them inside the saturated worker
+    // pool would starve jwalk's rayon::spawn and silently drop entries.
+    let image_walkers: Vec<_> = source_roots
+        .iter()
+        .map(|root| {
+            // Compute the output directory to exclude from scanning
+            let output_base_dir = get_base_output_dir(args, &root.path, "COCODataset");
+            WalkDir::new(&root.path)
+                .skip_hidden(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(move |e| {
+                    // Skip output directories early by comparing directory paths
+                    if e.file_type().is_dir() {
+                        let entry_path = e.path();
+                        // Skip if this directory is the output directory or inside it
+                        if entry_path.starts_with(&output_base_dir) {
+                            return false;
+                        }
+                        // Also skip legacy "COCODataset" directories for backward compatibility
+                        if let Some(name) = e.file_name().to_str() {
+                            return name != "COCODataset";
+                        }
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .filter(|e| e.file_type().is_file())
+                .filter_map(|e| {
+                    let path = e.path();
+                    if let Some(extension) = path.extension() {
+                        let ext = extension.to_string_lossy().to_lowercase();
+                        if image_extensions.contains(&ext) {
+                            return Some(path.to_path_buf());
+                        }
+                    }
+                    None
+                })
         })
-        .filter(|e| e.file_type().is_file())
-        .filter_map(|e| {
-            let path = e.path();
-            if let Some(extension) = path.extension() {
-                let ext = extension.to_string_lossy().to_lowercase();
-                if image_extensions.contains(&ext) {
-                    return Some(path.to_path_buf());
-                }
-            }
-            None
-        })
-        .par_bridge();
+        .collect();
+    let image_entries = image_walkers.into_iter().flatten().par_bridge();
 
     // Create a progress bar for background image processing
     let pb = indicatif::ProgressBar::new_spinner();

--- a/src/coco_dataset.rs
+++ b/src/coco_dataset.rs
@@ -18,8 +18,9 @@ use crate::coco::{Annotation, CocoConfig, CocoFile, Image};
 use crate::config::Args;
 use crate::types::{ImageAnnotation, Shape, SourceRoot};
 use crate::utils::{
-    create_io_thread_pool, create_output_directory, get_base_output_dir, infer_image_format,
-    read_and_parse_json, read_and_parse_json_buffered, read_and_parse_json_streaming,
+    create_io_thread_pool, create_output_directory, generate_collision_resistant_name,
+    get_base_output_dir, infer_image_format, read_and_parse_json, read_and_parse_json_buffered,
+    read_and_parse_json_streaming,
 };
 
 /// Struct to hold the paths to the output directories for COCO dataset
@@ -77,7 +78,7 @@ struct ProcessAnnotationParams<'a> {
     next_class_id: &'a Arc<AtomicUsize>,
     coco_config: &'a CocoConfig,
     processed_image_basenames: &'a DashSet<String>,
-    base_dir: &'a Path,
+    source_root: &'a SourceRoot,
     train_data: &'a Arc<Mutex<CocoSplitData>>,
     val_data: &'a Arc<Mutex<CocoSplitData>>,
     test_data: &'a Arc<Mutex<CocoSplitData>>,
@@ -301,7 +302,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                     next_class_id,
                     coco_config,
                     processed_image_basenames: &processed_image_basenames,
-                    base_dir: &root.path,
+                    source_root: root,
                     train_data: &train_data,
                     val_data: &val_data,
                     test_data: &test_data,
@@ -322,7 +323,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                         next_class_id,
                         coco_config,
                         processed_image_basenames: &processed_image_basenames,
-                        base_dir: &root.path,
+                        source_root: root,
                         train_data: &train_data,
                         val_data: &val_data,
                         test_data: &test_data,
@@ -340,7 +341,7 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
                     next_class_id,
                     coco_config,
                     processed_image_basenames: &processed_image_basenames,
-                    base_dir: &root.path,
+                    source_root: root,
                     train_data: &train_data,
                     val_data: &val_data,
                     test_data: &test_data,
@@ -457,6 +458,30 @@ fn process_json_files_for_coco(params: ProcessJsonFilesParams) -> ProcessJsonFil
     ))
 }
 
+/// Output file name for a COCO image: the original basename for single-root
+/// runs (existing behavior), or a root-qualified collision-resistant name when
+/// multiple source directories are converted together, so identical basenames
+/// from different roots do not overwrite each other.
+fn coco_output_file_name(source_root: &SourceRoot, image_path: &Path) -> String {
+    let file_name = image_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    if source_root.key_prefix.as_os_str().is_empty() {
+        return file_name.to_string();
+    }
+    let file_stem = image_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    let relative_path = source_root.key_path(image_path);
+    let base = generate_collision_resistant_name(file_stem, &relative_path);
+    match image_path.extension().and_then(|s| s.to_str()) {
+        Some(ext) => format!("{}.{}", base, ext),
+        None => base,
+    }
+}
+
 /// Process a single annotation for COCO conversion
 fn process_annotation_for_coco(params: ProcessAnnotationParams) {
     let ProcessAnnotationParams {
@@ -468,7 +493,7 @@ fn process_annotation_for_coco(params: ProcessAnnotationParams) {
         next_class_id,
         coco_config,
         processed_image_basenames,
-        base_dir,
+        source_root,
         train_data,
         val_data,
         test_data,
@@ -479,7 +504,7 @@ fn process_annotation_for_coco(params: ProcessAnnotationParams) {
     let image_path = json_path
         .parent()
         .map(|parent| parent.join(&annotation.image_path))
-        .unwrap_or_else(|| base_dir.join(&annotation.image_path));
+        .unwrap_or_else(|| source_root.path.join(&annotation.image_path));
 
     // Add labels to the label map if not using a predefined list and not in deterministic mode
     if args.label_list.is_empty() && !args.deterministic_labels {
@@ -521,24 +546,24 @@ fn process_annotation_for_coco(params: ProcessAnnotationParams) {
         }
     };
 
+    // Get the output file name for the image (root-qualified for multi-root runs)
+    let file_name = coco_output_file_name(source_root, &image_path);
+
     // Copy the image file with embedded image data support
-    if let Err(e) =
-        copy_image_for_coco_with_data(&image_path, images_dir, annotation.image_data.as_ref())
-    {
+    if let Err(e) = copy_image_for_coco_with_data(
+        &image_path,
+        images_dir,
+        annotation.image_data.as_ref(),
+        &file_name,
+    ) {
         warn!("Failed to copy image {}: {}", image_path.display(), e);
         return;
     }
 
-    // Get the file name for the image
-    let file_name = image_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown");
-
     // Create image entry
     let image = Image::new(
         0, // ID will be assigned later
-        file_name.to_string(),
+        file_name.clone(),
         annotation.image_width,
         annotation.image_height,
     );
@@ -581,42 +606,24 @@ fn process_annotation_for_coco(params: ProcessAnnotationParams) {
         }
     }
 
-    // Track processed image basenames
-    processed_image_basenames.insert(file_name.to_string());
+    // Track processed image output names
+    processed_image_basenames.insert(file_name);
 }
 
-/// Copy image file for COCO dataset with embedded image data support
+/// Copy image file for COCO dataset with embedded image data support.
+/// The image is written to `images_dir` as `output_file_name`.
 fn copy_image_for_coco_with_data(
     image_path: &Path,
     images_dir: &Path,
     image_data: Option<&String>,
+    output_file_name: &str,
 ) -> std::io::Result<()> {
     if image_path.exists() {
-        let file_name = image_path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Invalid file name: {:?}", image_path),
-                )
-            })?;
-
-        let dest_path = images_dir.join(file_name);
+        let dest_path = images_dir.join(output_file_name);
         fs::copy(image_path, dest_path)?;
     } else if let Some(image_data) = image_data {
         if !image_data.is_empty() {
             // Handle missing image file by extracting image_data from JSON
-            let file_name = image_path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("Invalid file name: {:?}", image_path),
-                    )
-                })?;
-
             // Infer image format by decoding just the header
             let image_extension = {
                 // Create a cursor to read from the base64 string
@@ -634,7 +641,9 @@ fn copy_image_for_coco_with_data(
             };
 
             // Create the output file with the correct extension
-            let dest_path = images_dir.join(file_name).with_extension(image_extension);
+            let dest_path = images_dir
+                .join(output_file_name)
+                .with_extension(image_extension);
 
             // Decode the full data and stream it to the file
             let mut cursor = std::io::Cursor::new(image_data);
@@ -832,12 +841,12 @@ fn process_background_images_for_coco(
                     }
                 })
                 .filter(|e| e.file_type().is_file())
-                .filter_map(|e| {
+                .filter_map(move |e| {
                     let path = e.path();
                     if let Some(extension) = path.extension() {
                         let ext = extension.to_string_lossy().to_lowercase();
                         if image_extensions.contains(&ext) {
-                            return Some(path.to_path_buf());
+                            return Some((root, path.to_path_buf()));
                         }
                     }
                     None
@@ -863,14 +872,11 @@ fn process_background_images_for_coco(
 
     // Process background images in parallel
     thread_pool.install(|| {
-        image_entries.for_each(|image_path| {
-            let file_name = image_path
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown");
+        image_entries.for_each(|(root, image_path)| {
+            let file_name = coco_output_file_name(root, &image_path);
 
             // Check if this image was already processed (has a JSON annotation)
-            if !processed_image_basenames.contains(file_name) {
+            if !processed_image_basenames.contains(&file_name) {
                 // This is a background image, process it
                 let (bg_images, images_dir) = {
                     use std::collections::hash_map::DefaultHasher;
@@ -897,7 +903,9 @@ fn process_background_images_for_coco(
                 };
 
                 // Copy the image file
-                if let Err(e) = copy_image_for_coco_with_data(&image_path, images_dir, None) {
+                if let Err(e) =
+                    copy_image_for_coco_with_data(&image_path, images_dir, None, &file_name)
+                {
                     warn!(
                         "Failed to copy background image {}: {}",
                         image_path.display(),
@@ -919,7 +927,7 @@ fn process_background_images_for_coco(
                     };
 
                     // Create image entry
-                    let image = Image::new(0, file_name.to_string(), image_width, image_height);
+                    let image = Image::new(0, file_name.clone(), image_width, image_height);
 
                     // Add to the appropriate split
                     if let Ok(mut images) = bg_images.lock() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,11 @@ use std::str::FromStr;
 #[derive(Parser, Debug, Clone)]
 #[command(version, long_about = None)]
 pub struct Args {
-    /// Directory containing LabelMe JSON files
-    #[arg(short = 'd', long = "json_dir")]
-    pub json_dir: String,
+    /// Directory containing LabelMe JSON files (repeat the flag to convert multiple directories)
+    #[arg(short = 'd', long = "json_dir", required = true)]
+    pub json_dir: Vec<String>,
 
-    /// Output directory for converted dataset (default: <json_dir>/YOLODataset or <json_dir>/COCODataset)
+    /// Output directory for converted dataset (default: <json_dir>/YOLODataset or <json_dir>/COCODataset; required when multiple json_dir values are given)
     #[arg(short = 'o', long = "output_dir")]
     pub output_dir: Option<String>,
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::config::{Args, Format};
-use crate::types::{ImageAnnotation, Shape, StreamingImageAnnotation};
+use crate::types::{ImageAnnotation, Shape, SourceRoot, StreamingImageAnnotation};
 use crate::utils::{generate_collision_resistant_name, infer_image_format};
 
 /// Configuration for processing a single annotation
@@ -19,7 +19,7 @@ pub struct AnnotationProcessor<'a> {
     pub label_map: &'a dashmap::DashMap<String, usize>,
     pub args: &'a Args,
     pub filename_cache: &'a Arc<DashMap<String, String>>,
-    pub base_dir: &'a Path,
+    pub source_root: &'a SourceRoot,
     pub stats: Option<&'a mut crate::types::ProcessingStats>,
 }
 
@@ -34,12 +34,13 @@ pub fn process_annotation(config: AnnotationProcessor<'_>) -> std::io::Result<()
         label_map,
         args,
         filename_cache,
-        base_dir,
+        source_root,
         stats,
     } = config;
 
-    // Calculate the relative path from the base directory
-    let relative_path = image_path.strip_prefix(base_dir).unwrap_or(image_path);
+    // Calculate the relative path from the source root, qualified to stay
+    // unique when multiple source directories are converted together
+    let relative_path = source_root.key_path(image_path);
 
     // Use the relative path as the cache key
     let cache_key = relative_path.to_string_lossy().to_string();
@@ -58,7 +59,7 @@ pub fn process_annotation(config: AnnotationProcessor<'_>) -> std::io::Result<()
         cached.clone()
     } else {
         // Generate a collision-resistant name using the file stem and relative path
-        let collision_resistant_name = generate_collision_resistant_name(file_stem, relative_path);
+        let collision_resistant_name = generate_collision_resistant_name(file_stem, &relative_path);
         filename_cache.insert(cache_key, collision_resistant_name.clone());
         collision_resistant_name
     };

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::config::Args;
-use crate::types::{OutputDirs, SplitData};
+use crate::types::{OutputDirs, SourceRoot, SplitData};
 use crate::utils::{
     create_io_thread_pool, create_output_directory, get_base_output_dir, read_and_parse_json,
     read_and_parse_json_buffered, read_and_parse_json_streaming,
@@ -46,7 +46,7 @@ pub fn setup_output_directories(args: &Args, dirname: &Path) -> std::io::Result<
 /// Process JSON files in a streaming fashion to reduce memory footprint
 /// Returns a set of processed image basenames for background image detection and processing statistics
 pub fn process_json_files_streaming(
-    dirname: &Path,
+    source_roots: &[SourceRoot],
     args: &Args,
     output_dirs: &OutputDirs,
     label_map: &dashmap::DashMap<String, usize>,
@@ -59,37 +59,45 @@ pub fn process_json_files_streaming(
     // Create a custom thread pool with limited concurrency
     let thread_pool = create_io_thread_pool(args.workers);
 
-    // Compute the output directory to exclude from scanning
-    let output_base_dir = get_base_output_dir(args, dirname, "YOLODataset");
-
-    // Walk through the directory structure to find JSON files using parallel jwalk
-    let json_entries = WalkDir::new(dirname)
-        .skip_hidden(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            // Skip output directories early by comparing directory paths
-            if e.file_type().is_dir() {
-                let entry_path = e.path();
-                // Skip if this directory is the output directory or inside it
-                if entry_path.starts_with(&output_base_dir) {
-                    return false;
-                }
-                // Also skip legacy "YOLODataset" directories for backward compatibility
-                if let Some(name) = e.file_name().to_str() {
-                    return name != "YOLODataset";
-                }
-                // If we can't convert to str, skip to be safe
-                false
-            } else {
-                true
-            }
+    // Walk through each source directory to find JSON files using parallel jwalk.
+    // The walkers must be created eagerly (collect) on the current thread: jwalk
+    // schedules its traversal with rayon::spawn, and creating a walker from inside
+    // the saturated worker pool below would starve that spawn and make jwalk
+    // silently return no entries after its startup timeout.
+    let json_walkers: Vec<_> = source_roots
+        .iter()
+        .map(|root| {
+            // Compute the output directory to exclude from scanning
+            let output_base_dir = get_base_output_dir(args, &root.path, "YOLODataset");
+            WalkDir::new(&root.path)
+                .skip_hidden(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(move |e| {
+                    // Skip output directories early by comparing directory paths
+                    if e.file_type().is_dir() {
+                        let entry_path = e.path();
+                        // Skip if this directory is the output directory or inside it
+                        if entry_path.starts_with(&output_base_dir) {
+                            return false;
+                        }
+                        // Also skip legacy "YOLODataset" directories for backward compatibility
+                        if let Some(name) = e.file_name().to_str() {
+                            return name != "YOLODataset";
+                        }
+                        // If we can't convert to str, skip to be safe
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .filter(|e| {
+                    e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
+                })
+                .map(move |e| (root, e.path().to_path_buf()))
         })
-        .filter(|e| {
-            e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
-        })
-        .map(|e| e.path().to_path_buf())
-        .par_bridge();
+        .collect();
+    let json_entries = json_walkers.into_iter().flatten().par_bridge();
 
     // Create a counter for tracking processed files
     let processed_count = std::sync::atomic::AtomicUsize::new(0);
@@ -118,7 +126,7 @@ pub fn process_json_files_streaming(
 
     // Process JSON files in parallel using the custom thread pool
     thread_pool.install(|| {
-        json_entries.for_each(|json_path| {
+        json_entries.for_each(|(root, json_path)| {
             // Increment total files processed counter
             if let Ok(mut stats) = stats.lock() {
                 stats.increment_total();
@@ -131,7 +139,7 @@ pub fn process_json_files_streaming(
                 let image_path = json_path
                     .parent()
                     .map(|parent| parent.join(&annotation.image_path))
-                    .unwrap_or_else(|| dirname.join(&annotation.image_path));
+                    .unwrap_or_else(|| root.path.join(&annotation.image_path));
 
                 // Add labels to the label map if not using a predefined list and not in deterministic mode
                 if args.label_list.is_empty() && !args.deterministic_labels {
@@ -205,7 +213,7 @@ pub fn process_json_files_streaming(
                     label_map,
                     args,
                     filename_cache: &filename_cache,
-                    base_dir: dirname,
+                    source_root: root,
                     stats: stats_ref_opt,
                 };
                 if let Err(e) = crate::conversion::process_annotation(processor) {
@@ -217,10 +225,8 @@ pub fn process_json_files_streaming(
                 }
 
                 // Track processed image basenames for background image detection
-                // Use the relative path as the cache key
-                let relative_path = image_path
-                    .strip_prefix(dirname)
-                    .unwrap_or(image_path.as_path());
+                // Use the root-qualified relative path as the cache key
+                let relative_path = root.key_path(&image_path);
                 let cache_key = relative_path.to_string_lossy().to_string();
 
                 // Use the sanitized name for collision-free tracking
@@ -232,7 +238,7 @@ pub fn process_json_files_streaming(
                         let collision_resistant_name =
                             crate::utils::generate_collision_resistant_name(
                                 file_stem,
-                                relative_path,
+                                &relative_path,
                             );
                         filename_cache.insert(cache_key, collision_resistant_name.clone());
                         collision_resistant_name
@@ -257,7 +263,7 @@ pub fn process_json_files_streaming(
                 let image_path = json_path
                     .parent()
                     .map(|parent| parent.join(&streaming_annotation.image_path))
-                    .unwrap_or_else(|| dirname.join(&streaming_annotation.image_path));
+                    .unwrap_or_else(|| root.path.join(&streaming_annotation.image_path));
 
                 // Add labels to the label map if not using a predefined list and not in deterministic mode
                 if args.label_list.is_empty() && !args.deterministic_labels {
@@ -331,7 +337,7 @@ pub fn process_json_files_streaming(
                     label_map,
                     args,
                     filename_cache: &filename_cache,
-                    base_dir: dirname,
+                    source_root: root,
                     stats: stats_ref_opt,
                 };
                 if let Err(e) = crate::conversion::process_annotation(processor) {
@@ -343,10 +349,8 @@ pub fn process_json_files_streaming(
                 }
 
                 // Track processed image basenames for background image detection
-                // Use the relative path as the cache key
-                let relative_path = image_path
-                    .strip_prefix(dirname)
-                    .unwrap_or(image_path.as_path());
+                // Use the root-qualified relative path as the cache key
+                let relative_path = root.key_path(&image_path);
                 let cache_key = relative_path.to_string_lossy().to_string();
 
                 // Use the sanitized name for collision-free tracking
@@ -358,7 +362,7 @@ pub fn process_json_files_streaming(
                         let collision_resistant_name =
                             crate::utils::generate_collision_resistant_name(
                                 file_stem,
-                                relative_path,
+                                &relative_path,
                             );
                         filename_cache.insert(cache_key, collision_resistant_name.clone());
                         collision_resistant_name
@@ -382,7 +386,7 @@ pub fn process_json_files_streaming(
                 let image_path = json_path
                     .parent()
                     .map(|parent| parent.join(&annotation.image_path))
-                    .unwrap_or_else(|| dirname.join(&annotation.image_path));
+                    .unwrap_or_else(|| root.path.join(&annotation.image_path));
 
                 // Add labels to the label map if not using a predefined list and not in deterministic mode
                 if args.label_list.is_empty() && !args.deterministic_labels {
@@ -456,7 +460,7 @@ pub fn process_json_files_streaming(
                     label_map,
                     args,
                     filename_cache: &filename_cache,
-                    base_dir: dirname,
+                    source_root: root,
                     stats: stats_ref_opt,
                 };
                 if let Err(e) = crate::conversion::process_annotation(processor) {
@@ -468,10 +472,8 @@ pub fn process_json_files_streaming(
                 }
 
                 // Track processed image basenames for background image detection
-                // Use the relative path as the cache key
-                let relative_path = image_path
-                    .strip_prefix(dirname)
-                    .unwrap_or(image_path.as_path());
+                // Use the root-qualified relative path as the cache key
+                let relative_path = root.key_path(&image_path);
                 let cache_key = relative_path.to_string_lossy().to_string();
 
                 // Use the sanitized name for collision-free tracking
@@ -483,7 +485,7 @@ pub fn process_json_files_streaming(
                         let collision_resistant_name =
                             crate::utils::generate_collision_resistant_name(
                                 file_stem,
-                                relative_path,
+                                &relative_path,
                             );
                         filename_cache.insert(cache_key, collision_resistant_name.clone());
                         collision_resistant_name
@@ -534,7 +536,7 @@ pub fn process_json_files_streaming(
 /// Process background images in a second pass
 /// This function processes images that don't have corresponding JSON annotations
 pub fn process_background_images(
-    dirname: &Path,
+    source_roots: &[SourceRoot],
     args: &Args,
     output_dirs: &OutputDirs,
     label_map: &dashmap::DashMap<String, usize>,
@@ -551,44 +553,51 @@ pub fn process_background_images(
     // Use the precomputed set of supported image extensions for fast lookup
     let image_extensions = crate::types::get_image_extensions_set();
 
-    // Compute the output directory to exclude from scanning
-    let output_base_dir = get_base_output_dir(args, dirname, "YOLODataset");
-
-    // Walk through the directory structure to find image files using parallel jwalk
-    let image_entries = WalkDir::new(dirname)
-        .skip_hidden(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            // Skip output directories early by comparing directory paths
-            if e.file_type().is_dir() {
-                let entry_path = e.path();
-                // Skip if this directory is the output directory or inside it
-                if entry_path.starts_with(&output_base_dir) {
-                    return false;
-                }
-                // Also skip legacy "YOLODataset" directories for backward compatibility
-                if let Some(name) = e.file_name().to_str() {
-                    return name != "YOLODataset";
-                }
-                // If we can't convert to str, skip to be safe
-                false
-            } else {
-                true
-            }
+    // Walk through each source directory to find image files using parallel jwalk.
+    // Walkers are created eagerly for the same reason as in
+    // process_json_files_streaming: creating them inside the saturated worker
+    // pool would starve jwalk's rayon::spawn and silently drop entries.
+    let image_walkers: Vec<_> = source_roots
+        .iter()
+        .map(|root| {
+            // Compute the output directory to exclude from scanning
+            let output_base_dir = get_base_output_dir(args, &root.path, "YOLODataset");
+            WalkDir::new(&root.path)
+                .skip_hidden(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(move |e| {
+                    // Skip output directories early by comparing directory paths
+                    if e.file_type().is_dir() {
+                        let entry_path = e.path();
+                        // Skip if this directory is the output directory or inside it
+                        if entry_path.starts_with(&output_base_dir) {
+                            return false;
+                        }
+                        // Also skip legacy "YOLODataset" directories for backward compatibility
+                        if let Some(name) = e.file_name().to_str() {
+                            return name != "YOLODataset";
+                        }
+                        // If we can't convert to str, skip to be safe
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .filter(|e| e.file_type().is_file())
+                .filter_map(move |e| {
+                    let path = e.path();
+                    if let Some(extension) = path.extension() {
+                        let ext = extension.to_string_lossy().to_lowercase();
+                        if image_extensions.contains(&ext) {
+                            return Some((root, path.to_path_buf()));
+                        }
+                    }
+                    None
+                })
         })
-        .filter(|e| e.file_type().is_file())
-        .filter_map(|e| {
-            let path = e.path();
-            if let Some(extension) = path.extension() {
-                let ext = extension.to_string_lossy().to_lowercase();
-                if image_extensions.contains(&ext) {
-                    return Some(path.to_path_buf());
-                }
-            }
-            None
-        })
-        .par_bridge();
+        .collect();
+    let image_entries = image_walkers.into_iter().flatten().par_bridge();
 
     // Create a counter for tracking processed background images
     let bg_processed_count = std::sync::atomic::AtomicUsize::new(0);
@@ -613,12 +622,10 @@ pub fn process_background_images(
 
     // Process background images in parallel using the custom thread pool
     thread_pool.install(|| {
-        image_entries.for_each(|image_path| {
+        image_entries.for_each(|(root, image_path)| {
             // Check if this image was already processed (has a JSON annotation)
-            // Use the relative path as the cache key
-            let relative_path = image_path
-                .strip_prefix(dirname)
-                .unwrap_or(image_path.as_path());
+            // Use the root-qualified relative path as the cache key
+            let relative_path = root.key_path(&image_path);
             let cache_key = relative_path.to_string_lossy().to_string();
 
             // Use the sanitized name for collision-free tracking
@@ -628,7 +635,7 @@ pub fn process_background_images(
                 } else {
                     // Generate a collision-resistant name using the file stem and relative path
                     let collision_resistant_name =
-                        crate::utils::generate_collision_resistant_name(file_stem, relative_path);
+                        crate::utils::generate_collision_resistant_name(file_stem, &relative_path);
                     filename_cache.insert(cache_key, collision_resistant_name.clone());
                     collision_resistant_name
                 };
@@ -677,7 +684,7 @@ pub fn process_background_images(
                         label_map,
                         args,
                         filename_cache: &filename_cache,
-                        base_dir: dirname,
+                        source_root: root,
                         stats: None, // No stats tracking for background images
                     };
                     if let Err(e) = crate::conversion::process_annotation(processor) {

--- a/src/labelme2coco.rs
+++ b/src/labelme2coco.rs
@@ -1,19 +1,22 @@
 use clap::Parser;
 use log::{error, info};
-use std::path::PathBuf;
 
-use labelme2yolo::{config::Args, process_coco_dataset, setup_coco_output_directories};
+use labelme2yolo::utils::resolve_source_dirs;
+use labelme2yolo::{config::Args, process_coco_dataset, setup_coco_output_directories, SourceRoot};
 
 fn main() {
     // Initialize the logger
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let args = Args::parse();
 
-    let dirname = PathBuf::from(&args.json_dir);
-    if !dirname.exists() {
-        error!("The specified json_dir does not exist: {}", args.json_dir);
-        return;
-    }
+    let dirs = match resolve_source_dirs(&args) {
+        Ok(dirs) => dirs,
+        Err(e) => {
+            error!("{}", e);
+            return;
+        }
+    };
+    let source_roots = SourceRoot::from_dirs(&dirs);
 
     info!("Starting LabelMe to COCO conversion process...");
 
@@ -26,9 +29,9 @@ fn main() {
         }
     };
 
-    match setup_coco_output_directories(&args, &dirname) {
+    match setup_coco_output_directories(&args, &source_roots[0].path) {
         Ok(output_dirs) => {
-            if let Err(e) = process_coco_dataset(&output_dirs, &args, &dirname, &coco_config) {
+            if let Err(e) = process_coco_dataset(&output_dirs, &args, &source_roots, &coco_config) {
                 error!("Failed to process dataset: {}", e);
             } else {
                 info!("COCO conversion process completed successfully.");

--- a/src/labelme2coco.rs
+++ b/src/labelme2coco.rs
@@ -1,10 +1,11 @@
 use clap::Parser;
 use log::{error, info};
+use std::process::ExitCode;
 
 use labelme2yolo::utils::resolve_source_dirs;
 use labelme2yolo::{config::Args, process_coco_dataset, setup_coco_output_directories, SourceRoot};
 
-fn main() {
+fn main() -> ExitCode {
     // Initialize the logger
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let args = Args::parse();
@@ -13,7 +14,7 @@ fn main() {
         Ok(dirs) => dirs,
         Err(e) => {
             error!("{}", e);
-            return;
+            return ExitCode::FAILURE;
         }
     };
     let source_roots = SourceRoot::from_dirs(&dirs);
@@ -25,7 +26,7 @@ fn main() {
         Ok(config) => config,
         Err(e) => {
             error!("Failed to parse COCO configuration: {}", e);
-            return;
+            return ExitCode::FAILURE;
         }
     };
 
@@ -33,10 +34,15 @@ fn main() {
         Ok(output_dirs) => {
             if let Err(e) = process_coco_dataset(&output_dirs, &args, &source_roots, &coco_config) {
                 error!("Failed to process dataset: {}", e);
-            } else {
-                info!("COCO conversion process completed successfully.");
+                return ExitCode::FAILURE;
             }
         }
-        Err(e) => error!("Failed to set up output directories: {}", e),
+        Err(e) => {
+            error!("Failed to set up output directories: {}", e);
+            return ExitCode::FAILURE;
+        }
     }
+
+    info!("COCO conversion process completed successfully.");
+    ExitCode::SUCCESS
 }

--- a/src/labelme2yolo.rs
+++ b/src/labelme2yolo.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
 
 use log::{error, info};
+use std::process::ExitCode;
 
 use labelme2yolo::utils::resolve_source_dirs;
 use labelme2yolo::{process_dataset, setup_output_directories, Args, SourceRoot};
 
-fn main() {
+fn main() -> ExitCode {
     // Initialize the logger
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let args = Args::parse();
@@ -14,7 +15,7 @@ fn main() {
         Ok(dirs) => dirs,
         Err(e) => {
             error!("{}", e);
-            return;
+            return ExitCode::FAILURE;
         }
     };
     let source_roots = SourceRoot::from_dirs(&dirs);
@@ -25,8 +26,14 @@ fn main() {
         Ok(output_dirs) => {
             if let Err(e) = process_dataset(&output_dirs, &args, &source_roots) {
                 error!("Failed to process dataset: {}", e);
+                return ExitCode::FAILURE;
             }
         }
-        Err(e) => error!("Failed to set up output directories: {}", e),
+        Err(e) => {
+            error!("Failed to set up output directories: {}", e);
+            return ExitCode::FAILURE;
+        }
     }
+
+    ExitCode::SUCCESS
 }

--- a/src/labelme2yolo.rs
+++ b/src/labelme2yolo.rs
@@ -1,26 +1,29 @@
 use clap::Parser;
 
 use log::{error, info};
-use std::path::PathBuf;
 
-use labelme2yolo::{process_dataset, setup_output_directories, Args};
+use labelme2yolo::utils::resolve_source_dirs;
+use labelme2yolo::{process_dataset, setup_output_directories, Args, SourceRoot};
 
 fn main() {
     // Initialize the logger
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let args = Args::parse();
 
-    let dirname = PathBuf::from(&args.json_dir);
-    if !dirname.exists() {
-        error!("The specified json_dir does not exist: {}", args.json_dir);
-        return;
-    }
+    let dirs = match resolve_source_dirs(&args) {
+        Ok(dirs) => dirs,
+        Err(e) => {
+            error!("{}", e);
+            return;
+        }
+    };
+    let source_roots = SourceRoot::from_dirs(&dirs);
 
     info!("Starting the conversion process...");
 
-    match setup_output_directories(&args, &dirname) {
+    match setup_output_directories(&args, &source_roots[0].path) {
         Ok(output_dirs) => {
-            if let Err(e) = process_dataset(&output_dirs, &args, &dirname) {
+            if let Err(e) = process_dataset(&output_dirs, &args, &source_roots) {
                 error!("Failed to process dataset: {}", e);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod yolo_dataset;
 // Re-export commonly used types and functions
 pub use config::{Args, Format};
 pub use io::{process_background_images, process_json_files_streaming, setup_output_directories};
-pub use types::{ImageAnnotation, OutputDirs, Shape, SplitData};
+pub use types::{ImageAnnotation, OutputDirs, Shape, SourceRoot, SplitData};
 pub use yolo_dataset::process_dataset;
 
 // COCO-specific exports

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,47 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+/// A source directory to scan for LabelMe annotations.
+///
+/// `key_prefix` disambiguates cache keys and generated filenames when multiple
+/// source directories are given: identical relative paths under different
+/// roots would otherwise map to the same collision hash and overwrite each
+/// other. It is empty for single-root invocations so generated names stay
+/// identical to earlier releases.
+#[derive(Debug, Clone)]
+pub struct SourceRoot {
+    pub path: PathBuf,
+    pub key_prefix: PathBuf,
+}
+
+impl SourceRoot {
+    /// Build source roots from the directories given on the command line,
+    /// assigning a unique key prefix to each root when more than one is given.
+    pub fn from_dirs(dirs: &[PathBuf]) -> Vec<SourceRoot> {
+        let multi = dirs.len() > 1;
+        dirs.iter()
+            .enumerate()
+            .map(|(index, dir)| SourceRoot {
+                path: dir.clone(),
+                key_prefix: if multi {
+                    PathBuf::from(index.to_string())
+                } else {
+                    PathBuf::new()
+                },
+            })
+            .collect()
+    }
+
+    /// Relative path used as the cache key and collision-hash input for a
+    /// file under this root.
+    pub fn key_path(&self, path: &Path) -> PathBuf {
+        let relative = path.strip_prefix(&self.path).unwrap_or(path);
+        self.key_prefix.join(relative)
+    }
+}
 
 // Supported image formats
 pub const IMG_FORMATS: &[&str] = &[
@@ -175,5 +215,40 @@ impl ProcessingStats {
                 self.skipped_no_image_data
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceRoot;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn single_root_key_path_matches_plain_relative_path() {
+        let roots = SourceRoot::from_dirs(&[PathBuf::from("data")]);
+        assert_eq!(roots.len(), 1);
+        assert_eq!(
+            roots[0].key_path(Path::new("data/sub/img.png")),
+            PathBuf::from("sub/img.png")
+        );
+    }
+
+    #[test]
+    fn multi_root_key_paths_differ_for_identical_relative_paths() {
+        let roots = SourceRoot::from_dirs(&[PathBuf::from("src-a"), PathBuf::from("src-b")]);
+        let a = roots[0].key_path(Path::new("src-a/img.png"));
+        let b = roots[1].key_path(Path::new("src-b/img.png"));
+        assert_ne!(a, b);
+        assert_eq!(a, PathBuf::from("0/img.png"));
+        assert_eq!(b, PathBuf::from("1/img.png"));
+    }
+
+    #[test]
+    fn key_path_falls_back_to_full_path_outside_root() {
+        let roots = SourceRoot::from_dirs(&[PathBuf::from("data")]);
+        assert_eq!(
+            roots[0].key_path(Path::new("elsewhere/img.png")),
+            PathBuf::from("elsewhere/img.png")
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,6 +20,49 @@ pub fn get_base_output_dir(args: &Args, json_dir_path: &Path, default_subdir: &s
     }
 }
 
+/// Validate the source directories given on the command line and return them
+/// with exact duplicates removed. Requires --output_dir when more than one
+/// directory is given, since the default output location would be ambiguous.
+pub fn resolve_source_dirs(args: &Args) -> Result<Vec<PathBuf>, String> {
+    let mut dirs: Vec<PathBuf> = Vec::with_capacity(args.json_dir.len());
+    let mut canonical_dirs: Vec<PathBuf> = Vec::with_capacity(args.json_dir.len());
+
+    for dir in &args.json_dir {
+        let path = PathBuf::from(dir);
+        if !path.exists() {
+            return Err(format!("The specified json_dir does not exist: {}", dir));
+        }
+        let canonical = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if canonical_dirs.contains(&canonical) {
+            log::warn!("Ignoring duplicate json_dir: {}", dir);
+            continue;
+        }
+        canonical_dirs.push(canonical);
+        dirs.push(path);
+    }
+
+    if dirs.len() > 1 && args.output_dir.is_none() {
+        return Err(
+            "--output_dir (-o) is required when multiple json_dir values are given".to_string(),
+        );
+    }
+
+    // Warn about nested roots: files under the inner root would be processed twice
+    for (i, outer) in canonical_dirs.iter().enumerate() {
+        for (j, inner) in canonical_dirs.iter().enumerate() {
+            if i != j && inner.starts_with(outer) {
+                log::warn!(
+                    "json_dir {} is nested inside {}; its files will be processed twice",
+                    dirs[j].display(),
+                    dirs[i].display()
+                );
+            }
+        }
+    }
+
+    Ok(dirs)
+}
+
 /// Helper function to infer image format from image bytes
 pub fn infer_image_format(image_bytes: &[u8]) -> Option<&'static str> {
     if image_bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,6 +41,10 @@ pub fn resolve_source_dirs(args: &Args) -> Result<Vec<PathBuf>, String> {
         dirs.push(path);
     }
 
+    if dirs.is_empty() {
+        return Err("At least one json_dir must be provided".to_string());
+    }
+
     if dirs.len() > 1 && args.output_dir.is_none() {
         return Err(
             "--output_dir (-o) is required when multiple json_dir values are given".to_string(),

--- a/src/yolo_dataset.rs
+++ b/src/yolo_dataset.rs
@@ -1,7 +1,6 @@
 use dashmap::{DashMap, DashSet};
 use log::info;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::{
     atomic::{AtomicUsize, Ordering::Relaxed},
     Arc,
@@ -9,14 +8,18 @@ use std::sync::{
 
 use crate::config::Args;
 use crate::io::{create_dataset_yaml, process_background_images, process_json_files_streaming};
-use crate::types::{OutputDirs, SplitData};
+use crate::types::{OutputDirs, SourceRoot, SplitData};
 
 /// Main dataset processing pipeline using streaming approach to reduce memory footprint
 pub fn process_dataset(
     output_dirs: &OutputDirs,
     args: &Args,
-    dirname: &Path,
+    source_roots: &[SourceRoot],
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if source_roots.is_empty() {
+        return Err("No source directories provided".into());
+    }
+
     // Use a local HashMap for initialization to avoid DashMap overhead
     let mut label_map_local = HashMap::new();
     let next_class_id = Arc::new(AtomicUsize::new(0));
@@ -51,7 +54,7 @@ pub fn process_dataset(
 
         // Pass 1: Gather label vocabulary only
         info!("Pass 1: Gathering label vocabulary...");
-        let all_labels = gather_label_vocabulary(dirname, args)?;
+        let all_labels = gather_label_vocabulary(source_roots, args)?;
         info!("Found {} unique labels.", all_labels.len());
 
         // Sort labels alphabetically for deterministic ID assignment
@@ -67,7 +70,7 @@ pub fn process_dataset(
         // Pass 2: Process files with pre-populated label map
         info!("Pass 2: Processing files with deterministic label mapping...");
         (processed_image_basenames, stats) = process_json_files_streaming(
-            dirname,
+            source_roots,
             args,
             output_dirs,
             &label_map,
@@ -80,7 +83,7 @@ pub fn process_dataset(
         // Single pass mode (existing behavior)
         info!("Processing JSON files in streaming fashion...");
         (processed_image_basenames, stats) = process_json_files_streaming(
-            dirname,
+            source_roots,
             args,
             output_dirs,
             &label_map,
@@ -94,7 +97,7 @@ pub fn process_dataset(
     // Second pass: process background images
     info!("Processing background images...");
     process_background_images(
-        dirname,
+        source_roots,
         args,
         output_dirs,
         &label_map,
@@ -103,7 +106,7 @@ pub fn process_dataset(
     info!("Background image processing complete.");
 
     info!("Creating dataset.yaml file...");
-    if let Err(e) = create_dataset_yaml(dirname, args, &label_map) {
+    if let Err(e) = create_dataset_yaml(&source_roots[0].path, args, &label_map) {
         return Err(format!("Failed to create dataset.yaml: {}", e).into());
     } else {
         info!("Conversion process completed successfully.");
@@ -114,7 +117,7 @@ pub fn process_dataset(
 
 /// Gather all unique labels from JSON files without processing them
 fn gather_label_vocabulary(
-    dirname: &Path,
+    source_roots: &[SourceRoot],
     _args: &Args,
 ) -> Result<std::collections::HashSet<String>, Box<dyn std::error::Error>> {
     use jwalk::WalkDir;
@@ -123,29 +126,37 @@ fn gather_label_vocabulary(
 
     let all_labels: DashSet<String> = DashSet::new();
 
-    // Walk through the directory structure to find JSON files
-    let json_entries = WalkDir::new(dirname)
-        .skip_hidden(false)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            // Skip YOLODataset directories early by comparing directory names directly
-            if e.file_type().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    name != "YOLODataset"
-                } else {
-                    // If we can't convert to str, skip to be safe
-                    false
-                }
-            } else {
-                true
-            }
+    // Walk through each source directory to find JSON files. The walkers must
+    // be created eagerly (collect): jwalk schedules its traversal with
+    // rayon::spawn, and creating a walker from a saturated rayon worker thread
+    // would starve that spawn and make jwalk silently return no entries.
+    let json_walkers: Vec<_> = source_roots
+        .iter()
+        .map(|root| {
+            WalkDir::new(&root.path)
+                .skip_hidden(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    // Skip YOLODataset directories early by comparing directory names directly
+                    if e.file_type().is_dir() {
+                        if let Some(name) = e.file_name().to_str() {
+                            name != "YOLODataset"
+                        } else {
+                            // If we can't convert to str, skip to be safe
+                            false
+                        }
+                    } else {
+                        true
+                    }
+                })
+                .filter(|e| {
+                    e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
+                })
+                .map(|e| e.path().to_path_buf())
         })
-        .filter(|e| {
-            e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "json")
-        })
-        .map(|e| e.path().to_path_buf())
-        .par_bridge();
+        .collect();
+    let json_entries = json_walkers.into_iter().flatten().par_bridge();
 
     // Process JSON files in parallel to gather labels
     json_entries.for_each(|json_path| {

--- a/tests/multi_dir.rs
+++ b/tests/multi_dir.rs
@@ -96,6 +96,10 @@ fn missing_dir_is_rejected_and_duplicates_are_removed() {
     let args = make_args(&["does-not-exist"], None);
     assert!(resolve_source_dirs(&args).is_err());
 
+    // Programmatic use with no directories at all must error, not panic later
+    let args = make_args(&[], None);
+    assert!(resolve_source_dirs(&args).is_err());
+
     let args = make_args(&[src_str, src_str], Some("out"));
     let dirs = resolve_source_dirs(&args).unwrap();
     assert_eq!(dirs.len(), 1);

--- a/tests/multi_dir.rs
+++ b/tests/multi_dir.rs
@@ -7,7 +7,10 @@ use std::path::Path;
 
 use labelme2yolo::config::{Format, SegmentationMode};
 use labelme2yolo::utils::resolve_source_dirs;
-use labelme2yolo::{process_dataset, setup_output_directories, Args, SourceRoot};
+use labelme2yolo::{
+    process_coco_dataset, process_dataset, setup_coco_output_directories, setup_output_directories,
+    Args, SourceRoot,
+};
 
 fn make_args(json_dirs: &[&str], output_dir: Option<&str>) -> Args {
     Args {
@@ -144,6 +147,65 @@ fn converts_multiple_dirs_with_identical_file_names() {
         yaml.contains("dog"),
         "dataset.yaml missing 'dog':\n{}",
         yaml
+    );
+}
+
+#[test]
+fn coco_multiple_dirs_keep_identical_file_names_apart() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("src-a");
+    let src_b = tmp.path().join("src-b");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(&src_a).unwrap();
+    fs::create_dir_all(&src_b).unwrap();
+
+    write_sample(&src_a, "img", "cat");
+    write_sample(&src_b, "img", "dog");
+
+    let args = make_args(
+        &[src_a.to_str().unwrap(), src_b.to_str().unwrap()],
+        Some(out.to_str().unwrap()),
+    );
+    let coco_config = args.to_coco_config().unwrap();
+    let dirs = resolve_source_dirs(&args).unwrap();
+    let source_roots = SourceRoot::from_dirs(&dirs);
+
+    let output_dirs = setup_coco_output_directories(&args, &source_roots[0].path).unwrap();
+    process_coco_dataset(&output_dirs, &args, &source_roots, &coco_config).unwrap();
+
+    // Both same-named images must exist as distinct files
+    let train_images: Vec<String> = fs::read_dir(out.join("images").join("train"))
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(train_images.len(), 2, "images: {:?}", train_images);
+
+    // The COCO JSON must reference exactly the file names written to disk
+    let json = fs::read_to_string(out.join("annotations").join("instances_train.json")).unwrap();
+    for name in &train_images {
+        assert!(json.contains(name), "{} missing from COCO JSON", name);
+    }
+}
+
+#[test]
+fn coco_single_dir_keeps_original_file_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    write_sample(&src, "img", "cat");
+
+    let args = make_args(&[src.to_str().unwrap()], None);
+    let coco_config = args.to_coco_config().unwrap();
+    let dirs = resolve_source_dirs(&args).unwrap();
+    let source_roots = SourceRoot::from_dirs(&dirs);
+
+    let output_dirs = setup_coco_output_directories(&args, &source_roots[0].path).unwrap();
+    process_coco_dataset(&output_dirs, &args, &source_roots, &coco_config).unwrap();
+
+    let out = src.join("COCODataset");
+    assert!(
+        out.join("images").join("train").join("img.png").exists(),
+        "single-root COCO output should keep the original basename"
     );
 }
 

--- a/tests/multi_dir.rs
+++ b/tests/multi_dir.rs
@@ -1,0 +1,164 @@
+//! Integration tests for converting multiple source directories in one run
+//! (https://github.com/GreatV/labelme2yolo/issues/87)
+
+use clap::Parser;
+use std::fs;
+use std::path::Path;
+
+use labelme2yolo::config::{Format, SegmentationMode};
+use labelme2yolo::utils::resolve_source_dirs;
+use labelme2yolo::{process_dataset, setup_output_directories, Args, SourceRoot};
+
+fn make_args(json_dirs: &[&str], output_dir: Option<&str>) -> Args {
+    Args {
+        json_dir: json_dirs.iter().map(|s| s.to_string()).collect(),
+        output_dir: output_dir.map(|s| s.to_string()),
+        val_size: 0.0,
+        test_size: 0.0,
+        output_format: Format::Bbox,
+        seed: 42,
+        include_background: false,
+        label_list: Vec::new(),
+        workers: 1,
+        deterministic_labels: false,
+        buffer_size_kib: 64,
+        segmentation_mode: SegmentationMode::Polygon,
+        start_ids: "image=1,ann=1".to_string(),
+        categories_from: "inferred".to_string(),
+    }
+}
+
+/// Write a minimal LabelMe annotation plus a dummy image file into `dir`
+fn write_sample(dir: &Path, stem: &str, label: &str) {
+    let image_name = format!("{}.png", stem);
+    let json = format!(
+        r#"{{
+            "version": "5.0.1",
+            "flags": {{}},
+            "shapes": [
+                {{
+                    "label": "{}",
+                    "points": [[10.0, 10.0], [50.0, 50.0]],
+                    "group_id": null,
+                    "shape_type": "rectangle",
+                    "description": null,
+                    "mask": null
+                }}
+            ],
+            "imagePath": "{}",
+            "imageData": null,
+            "imageHeight": 100,
+            "imageWidth": 100
+        }}"#,
+        label, image_name
+    );
+    fs::write(dir.join(format!("{}.json", stem)), json).unwrap();
+    // Content is only copied, never decoded, so any bytes work as an image
+    fs::write(dir.join(image_name), b"fake png bytes").unwrap();
+}
+
+fn count_files(dir: &Path) -> usize {
+    fs::read_dir(dir).map(|d| d.count()).unwrap_or(0)
+}
+
+#[test]
+fn cli_accepts_repeated_json_dir_flag() {
+    let args = Args::try_parse_from(["labelme2yolo", "-d", "src-a", "-d", "src-b", "-o", "out"])
+        .expect("repeated -d should parse");
+    assert_eq!(args.json_dir, vec!["src-a", "src-b"]);
+
+    assert!(
+        Args::try_parse_from(["labelme2yolo"]).is_err(),
+        "-d should be required"
+    );
+}
+
+#[test]
+fn multiple_dirs_require_output_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("src-a");
+    let src_b = tmp.path().join("src-b");
+    fs::create_dir_all(&src_a).unwrap();
+    fs::create_dir_all(&src_b).unwrap();
+
+    let args = make_args(&[src_a.to_str().unwrap(), src_b.to_str().unwrap()], None);
+    let err = resolve_source_dirs(&args).unwrap_err();
+    assert!(err.contains("--output_dir"), "unexpected error: {}", err);
+}
+
+#[test]
+fn missing_dir_is_rejected_and_duplicates_are_removed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    let src_str = src.to_str().unwrap();
+
+    let args = make_args(&["does-not-exist"], None);
+    assert!(resolve_source_dirs(&args).is_err());
+
+    let args = make_args(&[src_str, src_str], Some("out"));
+    let dirs = resolve_source_dirs(&args).unwrap();
+    assert_eq!(dirs.len(), 1);
+}
+
+#[test]
+fn converts_multiple_dirs_with_identical_file_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_a = tmp.path().join("src-a");
+    let src_b = tmp.path().join("src-b");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(&src_a).unwrap();
+    fs::create_dir_all(&src_b).unwrap();
+
+    // Same file names in both directories: the outputs must not overwrite
+    // each other
+    write_sample(&src_a, "img", "cat");
+    write_sample(&src_b, "img", "dog");
+
+    let args = make_args(
+        &[src_a.to_str().unwrap(), src_b.to_str().unwrap()],
+        Some(out.to_str().unwrap()),
+    );
+    let dirs = resolve_source_dirs(&args).unwrap();
+    let source_roots = SourceRoot::from_dirs(&dirs);
+
+    let output_dirs = setup_output_directories(&args, &source_roots[0].path).unwrap();
+    process_dataset(&output_dirs, &args, &source_roots).unwrap();
+
+    // val_size = 0.0, so everything lands in train
+    assert_eq!(count_files(&out.join("images").join("train")), 2);
+    assert_eq!(count_files(&out.join("labels").join("train")), 2);
+
+    // Both labels must appear in dataset.yaml
+    let yaml = fs::read_to_string(out.join("dataset.yaml")).unwrap();
+    assert!(
+        yaml.contains("cat"),
+        "dataset.yaml missing 'cat':\n{}",
+        yaml
+    );
+    assert!(
+        yaml.contains("dog"),
+        "dataset.yaml missing 'dog':\n{}",
+        yaml
+    );
+}
+
+#[test]
+fn single_dir_conversion_still_works() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    write_sample(&src, "img", "cat");
+
+    // No --output_dir: default <json_dir>/YOLODataset is used
+    let args = make_args(&[src.to_str().unwrap()], None);
+    let dirs = resolve_source_dirs(&args).unwrap();
+    let source_roots = SourceRoot::from_dirs(&dirs);
+
+    let output_dirs = setup_output_directories(&args, &source_roots[0].path).unwrap();
+    process_dataset(&output_dirs, &args, &source_roots).unwrap();
+
+    let out = src.join("YOLODataset");
+    assert_eq!(count_files(&out.join("images").join("train")), 1);
+    assert_eq!(count_files(&out.join("labels").join("train")), 1);
+}


### PR DESCRIPTION
Closes #87.

## What

`-d/--json_dir` can now be repeated to convert several source directories into one dataset, for both `labelme2yolo` and `labelme2coco`:

```shell
labelme2yolo -d src-a -d src-b -o out
```

Single `-d` usage is fully backward compatible, including identical generated filenames.

## How

- **CLI** (`config.rs`): `json_dir` becomes a repeatable `Vec<String>`.
- **Validation** (`utils.rs`): new `resolve_source_dirs` checks each directory exists, drops exact duplicates, warns on nested roots, and errors if multiple `-d` are given without `-o` (the default output location would be ambiguous).
- **Pipeline**: new `SourceRoot` type pairs each directory with a key prefix. All five directory walks scan every root and carry the owning root with each file, so relative-path stripping and embedded-image fallbacks use the correct base. The collision-resistant filename hash is root-qualified when multiple roots are given, so `src-a/img.png` and `src-b/img.png` land as distinct output files instead of overwriting each other.
- **jwalk fix**: walkers are now created eagerly before `par_bridge`. jwalk launches its traversal via `rayon::spawn` at walker creation; created lazily on a thread inside the saturated custom pool, that spawn starves, jwalk's startup check times out, and it silently returns an empty iterator (nondeterministically dropped files during testing).

## Testing

- New `tests/multi_dir.rs`: repeated `-d` parsing, `-o` requirement, missing/duplicate dir handling, same-named files across dirs producing two outputs with both labels in `dataset.yaml`, and a single-dir regression test.
- Exercised both binaries end-to-end: multi-dir YOLO, COCO (correct image/annotation counts), `--deterministic_labels`, `--include_background`, and error paths. 12/12 stress runs stable.
- `cargo test` (10 passed), `cargo clippy --all-targets` and `cargo fmt --check` clean.

Note: COCO mode's pre-existing basename collision on copied images (same filename in different subdirectories) is unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)