### PR TITLE
chore: Add crates.io package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "labelme2yolo"
 version = "0.4.0"
 edition = "2021"
+description = "Convert LabelMe JSON annotations to YOLO or COCO dataset formats"
+license = "MIT"
+repository = "https://github.com/GreatV/labelme2yolo"
+readme = "README.md"
+keywords = ["labelme", "yolo", "coco", "annotation", "dataset"]
+categories = ["command-line-utilities", "computer-vision"]
 
 [[bin]]
 name = "labelme2yolo"


### PR DESCRIPTION
Adds the `description`, `license`, `repository`, `readme`, `keywords`, and `categories` fields required for the first `cargo publish` of v0.4.0 to crates.io. `cargo publish --dry-run` passes (24 files, 42.7KiB compressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)